### PR TITLE
add new config API for use with SDK 5.14.0+, similar to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This version of the library is compatible with .NET Framework version 4.5 and ab
 
 ## Caching behavior
 
-The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
+The LaunchDarkly SDK has a standard caching mechanism for any persistent data store, to reduce database traffic. This is configured through the SDK's `PersistentDataStoreBuilder` class as described in the SDK documentation. For instance, to specify a cache TTL of 5 minutes:
 
 ```csharp
         var config = Configuration.Default("YOUR_SDK_KEY")

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBComponents.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBComponents.cs
@@ -1,4 +1,6 @@
-﻿namespace LaunchDarkly.Client.DynamoDB
+﻿using System;
+
+namespace LaunchDarkly.Client.DynamoDB
 {
     /// <summary>
     /// Obsolete entry point for the DynamoDB integration.

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBComponents.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBComponents.cs
@@ -1,40 +1,17 @@
 ﻿namespace LaunchDarkly.Client.DynamoDB
 {
     /// <summary>
-    /// Entry point for using the DynamoDB feature store with the LaunchDarkly SDK.
-    /// 
-    /// For more details about how and why you can use a persistent feature store, see:
-    /// https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store
-    /// 
-    /// To use the DynamoDB feature store with the LaunchDarkly client, you will first obtain a
-    /// builder by calling <see cref="DynamoDBComponents.DynamoDBFeatureStore(string)"/>,
-    /// then optionally  modify its properties, and then include it in your client configuration.
-    /// For example:
-    /// 
-    /// <code>
-    /// using LaunchDarkly.Client;
-    /// using LaunchDarkly.Client.DynamoDB;
-    /// 
-    /// var store = DynamoDBComponents.DynamoDBFeatureStore("my-table-name")
-    ///     .WithCaching(FeatureStoreCaching.Enabled.WithTtlSeconds(30));
-    /// var config = Configuration.Default("my-sdk-key")
-    ///     .WithFeatureStoreFactory(store);
-    /// </code>
-    /// 
-    /// Note that the specified table must already exist in DynamoDB. It must have a partition key
-    /// of "namespace", and a sort key of "key".
-    /// 
-    /// By default, the feature store uses a basic DynamoDB client configuration that takes its
-    /// AWS credentials and region from AWS environment variables and/or local configuration files.
-    /// There are options in the builder for changing some configuration options, or you can
-    /// configure the DynamoDB client yourself and pass it to the builder with
-    /// <see cref="DynamoDBFeatureStoreBuilder.WithExistingClient(Amazon.DynamoDBv2.AmazonDynamoDBClient)"/>.
-    /// 
-    /// If you are using the same DynamoDB table as a feature store for multiple LaunchDarkly
-    /// environments, use the <see cref="DynamoDBFeatureStoreBuilder.WithPrefix(string)"/>
-    /// option and choose a different prefix string for each, so they will not interfere with each
-    /// other's data. 
+    /// Obsolete entry point for the DynamoDB integration.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is retained in version 1.2 of the library for backward compatibility. For the new
+    /// preferred way to configure the DynamoDB integration, see <see cref="LaunchDarkly.Client.Integrations.DynamoDB"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.DynamoDB")]
     public abstract class DynamoDBComponents
     {
         /// <summary>

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBFeatureStoreBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Amazon.DynamoDBv2;
+﻿using System;
+using Amazon.DynamoDBv2;
 using Amazon.Runtime;
 using LaunchDarkly.Client.Utils;
 

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBFeatureStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBFeatureStoreBuilder.cs
@@ -5,15 +5,17 @@ using LaunchDarkly.Client.Utils;
 namespace LaunchDarkly.Client.DynamoDB
 {
     /// <summary>
-    /// Builder for a DynamoDB-based implementation of <see cref="IFeatureStore"/>.
-    /// Create an instance of the builder by calling <see cref="DynamoDBComponents.DynamoDBFeatureStore"/>;
-    /// configure it using the setter methods; then pass the builder to
-    /// <see cref="ConfigurationExtensions.WithFeatureStore(Configuration, IFeatureStore)"/>.
-    /// 
-    /// The AWS SDK provides many configuration options for a DynamoDB client. This class has
-    /// corresponding methods for some of the most commonly used ones, but also allows you to use
-    /// AWS SDK classes to access the full range of options.
+    /// Obsolete builder for the DynamoDB data store.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This class is retained in version 1.1 of the library for backward compatibility. For the new
+    /// preferred way to configure the DynamoDB integration, see <see cref="LaunchDarkly.Client.Integrations.DynamoDB"/>.
+    /// Updating to the latter now will make it easier to adopt version 6.0 of the LaunchDarkly .NET SDK, since
+    /// an identical API is used there (except for the base namespace).
+    /// </para>
+    /// </remarks>
+    [Obsolete("Use LaunchDarkly.Client.Integrations.DynamoDB")]
     public sealed class DynamoDBFeatureStoreBuilder : IFeatureStoreFactory
     {
         private AmazonDynamoDBClient _existingClient = null;

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDB.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDB.cs
@@ -19,11 +19,11 @@ namespace LaunchDarkly.Client.Integrations
         public const string DataStoreSortKey = "key";
 
         /// <summary>
-        /// Returns a builder object for creating a Redis-backed data store.
+        /// Returns a builder object for creating a DynamoDB-backed data store.
         /// </summary>
         /// <remarks>
         /// This object can be modified with <see cref="DynamoDBDataStoreBuilder"/> methods for any desired
-        /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
+        /// custom DynamoDB options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
         /// and set any desired caching options. Finally, pass the result to <see cref="IConfigurationBuilder.DataStore(Interfaces.IFeatureStoreFactory)"/>.
         /// </remarks>
         /// <example>

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDB.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDB.cs
@@ -1,0 +1,45 @@
+﻿
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// Integration between the LaunchDarkly SDK and DynamoDB.
+    /// </summary>
+    public static class DynamoDB
+    {
+        /// <summary>
+        /// Name of the partition key that the data store's table must have. You must specify
+        /// this when you create the table. The key type must be String.
+        /// </summary>
+        public const string DataStorePartitionKey = "namespace";
+
+        /// <summary>
+        /// Name of the sort key that the data store's table must have. You must specify this
+        /// when you create the table. The key type must be String.
+        /// </summary>
+        public const string DataStoreSortKey = "key";
+
+        /// <summary>
+        /// Returns a builder object for creating a Redis-backed data store.
+        /// </summary>
+        /// <remarks>
+        /// This object can be modified with <see cref="DynamoDBDataStoreBuilder"/> methods for any desired
+        /// custom Redis options. Then, pass it to <see cref="Components.PersistentDataStore(Interfaces.IPersistentDataStoreAsyncFactory)"/>
+        /// and set any desired caching options. Finally, pass the result to <see cref="IConfigurationBuilder.DataStore(Interfaces.IFeatureStoreFactory)"/>.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        ///     var config = Configuration.Builder("sdk-key")
+        ///         .DataStore(
+        ///             Components.PersistentDataStore(
+        ///                 DynamoDB.DataStore("table-name")
+        ///             ).CacheSeconds(15)
+        ///         )
+        ///         .Build();
+        /// </code>
+        /// </example>
+        /// <param name="tableName">the DynamoDB table name; this table must already exist</param>
+        /// <returns>a data store configuration object</returns>
+        public static DynamoDBDataStoreBuilder DataStore(string tableName) =>
+            new DynamoDBDataStoreBuilder(tableName);
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDBDataStoreBuilder.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/Integrations/DynamoDBDataStoreBuilder.cs
@@ -1,0 +1,158 @@
+﻿using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using LaunchDarkly.Client.Interfaces;
+using LaunchDarkly.Client.Utils;
+
+namespace LaunchDarkly.Client.Integrations
+{
+    /// <summary>
+    /// A builder for configuring the DynamoDB-based persistent data store.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Obtain an instance of this class by calling <see cref="DynamoDB.DataStore(string)"/>. After calling its methods
+    /// to specify any desired custom settings, wrap it in a <see cref="PersistentDataStoreBuilder"/>
+    /// by calling <see cref="Components.PersistentDataStore(IPersistentDataStoreAsyncFactory)"/>, then pass
+    /// the result into the SDK configuration with <see cref="IConfigurationBuilder.DataStore(IFeatureStoreFactory)"/>.
+    /// You do not need to call <see cref="CreatePersistentDataStore()"/> yourself to build
+    /// the actual data store; that will be done by the SDK.
+    /// </para>
+    /// <para>
+    /// The AWS SDK provides many configuration options for a DynamoDB client. This class has
+    /// corresponding methods for some of the most commonly used ones. If you need more sophisticated
+    /// control over the DynamoDB client, you can construct one of your own and pass it in with the
+    /// <see cref="ExistingClient(AmazonDynamoDBClient)"/> method.
+    /// </para>
+    /// <para>
+    /// Builder calls can be chained, for example:
+    /// </para>
+    /// <code>
+    ///     var config = Configuration.Builder("sdk-key")
+    ///         .DataStore(
+    ///             Components.PersistentDataStore(
+    ///                 DynamoDB.DataStore("my-table-name")
+    ///                     .Credentials(myAWSCredentials)
+    ///                     .Prefix("app1")
+    ///                 )
+    ///                 .CacheSeconds(15)
+    ///             )
+    ///         .Build();
+    /// </code>
+    /// </remarks>
+    public sealed class DynamoDBDataStoreBuilder : IPersistentDataStoreAsyncFactory
+    {
+        private AmazonDynamoDBClient _existingClient = null;
+        private AWSCredentials _credentials = null;
+        private AmazonDynamoDBConfig _config = null;
+
+        private readonly string _tableName;
+        private string _prefix = "";
+
+        internal DynamoDBDataStoreBuilder(string tableName)
+        {
+            _tableName = tableName;
+        }
+
+        /// <summary>
+        /// Specifies an existing, already-configured DynamoDB client instance that the data store
+        /// should use rather than creating one of its own.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If you specify an existing client, then the other builder methods for configuring DynamoDB
+        /// are ignored.
+        /// </para>
+        /// <para>
+        /// Note that the LaunchDarkly code will <i>not</i> take ownership of the lifecycle of this
+        /// object: in other words, it will not call <c>Dispose()</c> on the <c>AmazonDynamoDBClient</c> when
+        /// you dispose of the SDK client, as it would if it had created the <c>AmazonDynamoDBClient</c> itself.
+        /// It is your responsibility to call <c>Dispose()</c> on the <c>AmazonDynamoDBClient</c> when you are
+        /// done with it.
+        /// </para>
+        /// </remarks>
+        /// <param name="client">an existing DynamoDB client instance</param>
+        /// <returns>the builder</returns>
+        public DynamoDBDataStoreBuilder ExistingClient(AmazonDynamoDBClient client)
+        {
+            _existingClient = client;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the AWS client credentials.
+        /// </summary>
+        /// <remarks>
+        /// If you do not set them programmatically, the AWS SDK will attempt to find them in
+        /// environment variables and/or local configuration files.
+        /// </remarks>
+        /// <param name="credentials">the AWS credentials</param>
+        /// <returns>the builder</returns>
+        public DynamoDBDataStoreBuilder Credentials(AWSCredentials credentials)
+        {
+            _credentials = credentials;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies an entire DynamoDB configuration.
+        /// </summary>
+        /// <remarks>
+        /// If this is not provided explicitly, the AWS SDK will attempt to determine your
+        /// current region based on environment variables and/or local configuration files.
+        /// </remarks>
+        /// <param name="config">a DynamoDB configuration object</param>
+        /// <returns>the builder</returns>
+        public DynamoDBDataStoreBuilder Configuration(AmazonDynamoDBConfig config)
+        {
+            _config = config;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets an optional namespace prefix for all keys stored in DynamoDB.
+        /// </summary>
+        /// <remarks>
+        /// You may use this if you are sharing the same database table between multiple clients that
+        /// are for different LaunchDarkly environments, to avoid key collisions. However, in DynamoDB
+        /// it is common to use separate tables rather than share a single table for unrelated
+        /// applications, so by default there is no prefix.
+        /// </remarks>
+        /// <param name="prefix">the namespace prefix; null for no prefix</param>
+        /// <returns>the builder</returns>
+        public DynamoDBDataStoreBuilder Prefix(string prefix)
+        {
+            _prefix = prefix;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IFeatureStoreCoreAsync CreatePersistentDataStore() =>
+            new LaunchDarkly.Client.DynamoDB.DynamoDBFeatureStoreCore(
+                MakeClient(),
+                _tableName,
+                _prefix
+                );
+
+        private AmazonDynamoDBClient MakeClient()
+        {
+            if (_existingClient != null)
+            {
+                return _existingClient;
+            }
+            // Unfortunately, the AWS SDK does not believe in builders
+            if (_credentials == null)
+            {
+                if (_config == null)
+                {
+                    return new AmazonDynamoDBClient();
+                }
+                return new AmazonDynamoDBClient(_config);
+            }
+            if (_config == null)
+            {
+                return new AmazonDynamoDBClient(_credentials);
+            }
+            return new AmazonDynamoDBClient(_credentials, _config);
+        }
+    }
+}

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.15.2" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.1.0-alpha.1</Version>
     <PackageId>LaunchDarkly.ServerSdk.DynamoDB</PackageId>
     <AssemblyName>LaunchDarkly.ServerSdk.DynamoDB</AssemblyName>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
@@ -13,9 +13,12 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.15.2" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.14.0-alpha.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Integrations\" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\LaunchDarkly.ServerSdk.DynamoDB.xml</DocumentationFile>
   </PropertyGroup>

--- a/test/LaunchDarkly.ServerSdk.DynamoDB.Tests/DynamoDBFeatureStoreTest.cs
+++ b/test/LaunchDarkly.ServerSdk.DynamoDB.Tests/DynamoDBFeatureStoreTest.cs
@@ -20,25 +20,24 @@ namespace LaunchDarkly.Client.DynamoDB.Tests
         protected override IFeatureStore CreateStoreImpl(FeatureStoreCacheConfig caching)
         {
             CreateTableIfNecessary();
-            return BaseBuilder()
-                .WithCaching(caching)
+            return Components.PersistentDataStore(BaseBuilder())
+                .CacheTime(caching.Ttl)
                 .CreateFeatureStore();
         }
         
         protected override IFeatureStore CreateStoreImplWithPrefix(string prefix)
         {
             CreateTableIfNecessary();
-            return BaseBuilder()
-                .WithCaching(FeatureStoreCacheConfig.Disabled)
-                .WithPrefix(prefix)
+            return Components.PersistentDataStore(BaseBuilder().Prefix(prefix))
+                .NoCaching()
                 .CreateFeatureStore();
         }
 
-        private DynamoDBFeatureStoreBuilder BaseBuilder()
+        private Integrations.DynamoDBDataStoreBuilder BaseBuilder()
         {
-            return DynamoDBComponents.DynamoDBFeatureStore(TableName)
-                .WithCredentials(MakeTestCredentials())
-                .WithConfiguration(MakeTestConfiguration());
+            return Integrations.DynamoDB.DataStore(TableName)
+                .Credentials(MakeTestCredentials())
+                .Configuration(MakeTestConfiguration());
         }
 
         private AWSCredentials MakeTestCredentials()


### PR DESCRIPTION
This is for the 1.1 release of LaunchDarkly.ServerSdk.DynamoDB; the other PR is for the 2.0 release.

In 1.1, we're deprecating the old DynamoDB config builder, and adding a new entry point and builder that look like the ones we'll be using in 2.0. This corresponds to the .SDK 5.14.0 release which will add configuration APIs that are basically the same as they'll be in 6.0. So, developers who update to this now will have minimal migration to do for SDK 6.0 (except for a search-and-replace to change the namespace from `LaunchDarkly.Client` to `LaunchDarkly.Sdk.Server`. This is basically the same as what we did for Java SDK 5.