### PR TITLE
2.0

### DIFF
--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests.Tests/LaunchDarkly.ServerSdk.SharedTests.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
+++ b/dotnet-server-sdk-shared-tests/LaunchDarkly.ServerSdk.SharedTests/LaunchDarkly.ServerSdk.SharedTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/LaunchDarkly.ServerSdk.DynamoDB.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.15.2" />
-    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.6.4" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.20" />
+    <PackageReference Include="LaunchDarkly.ServerSdk" Version="5.13.1" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/test/LaunchDarkly.ServerSdk.DynamoDB.Tests/LaunchDarkly.ServerSdk.DynamoDB.Tests.csproj
+++ b/test/LaunchDarkly.ServerSdk.DynamoDB.Tests/LaunchDarkly.ServerSdk.DynamoDB.Tests.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remaining on AWSSDK.DynamoDBv2 3.3.* will cause issues for other projects that want to update e.g. Amazon.Lambda.DynamoDBEvents to 1.2.0 or some other AWS reference that requires aws sdk core lib 1.5.*.