### PR TITLE
Only dispose of DynamoDB client when it was created by this integration

### DIFF
--- a/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBStoreImplBase.cs
+++ b/src/LaunchDarkly.ServerSdk.DynamoDB/DynamoDBStoreImplBase.cs
@@ -50,7 +50,7 @@ namespace LaunchDarkly.Sdk.Server.Integrations
         {
             if (disposing)
             {
-                if (_wasExistingClient)
+                if (!_wasExistingClient)
                 {
                     _client.Dispose();
                 }


### PR DESCRIPTION
An inverted conditional caused this integration to dispose of the DynamoDB client only when the client was _not_ created by the integration, rather than only when the client was created by the integration.